### PR TITLE
Added option to create signed JWTs using preconstructed JSON.

### DIFF
--- a/src/jwt/JWT.hx
+++ b/src/jwt/JWT.hx
@@ -71,6 +71,17 @@ class JWT {
      @return String
      */
     public static function sign(payload:Dynamic, secret:String, ?replacer:Dynamic->Dynamic->Dynamic, ?header:JWTHeader):String {
+        return signPreconstructed(Json.stringify(payload, replacer), secret, header);
+    }
+
+    /**
+     Creates a signed JWT
+     @param header - header information. If null, will default to HS256 encryption
+     @param payload - The data to include
+     @param secret - The secret to generate the signature with
+     @return String
+     */
+    public static function signPreconstructed(payload:String, secret:String, ?header:JWTHeader):String {
         if(header == null) {
             header = {
                 alg: JWTAlgorithm.HS256,
@@ -81,9 +92,8 @@ class JWT {
         var alg:JWTAlgorithm = header.alg == null ? JWTAlgorithm.HS256 : header.alg;
 
         var h:String = Json.stringify(header);
-        var p:String = Json.stringify(payload, replacer);
         var hb64:String = base64url_encode(Bytes.ofString(h));
-        var pb64:String = base64url_encode(Bytes.ofString(p));
+        var pb64:String = base64url_encode(Bytes.ofString(payload));
         var sb:Bytes = switch(alg) {
             case JWTAlgorithm.HS256: signature(alg, hb64 + "." + pb64, secret);
             default: throw 'The ${cast(alg)} algorithm isn\'t supported yet!';


### PR DESCRIPTION
We're using this library to send JWTs to a backend that requires JWT
payloads to be in a specific order.  The order of fields in Haxe is
implementation-dependent, so we want to just pass in preconstructed
JSON.